### PR TITLE
feature-BJS2-27251 google calendar controller

### DIFF
--- a/src/main/java/faang/school/projectservice/client/UserServiceClient.java
+++ b/src/main/java/faang/school/projectservice/client/UserServiceClient.java
@@ -12,7 +12,7 @@ import java.util.List;
 @FeignClient(name = "user-service", url = "${services.user-service.host}:${services.user-service.port}")
 public interface UserServiceClient {
 
-    @GetMapping("/user/{userId}")
+    @GetMapping("/users/{userId}")
     UserDto getUser(@PathVariable long userId);
 
     @PostMapping("/users")

--- a/src/main/java/faang/school/projectservice/controller/calendar/GoogleCalendarController.java
+++ b/src/main/java/faang/school/projectservice/controller/calendar/GoogleCalendarController.java
@@ -1,0 +1,40 @@
+package faang.school.projectservice.controller.calendar;
+
+import faang.school.projectservice.dto.google.calendar.CalendarEventDto;
+import faang.school.projectservice.google.calendar.GoogleCalendarService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/calendar")
+public class GoogleCalendarController {
+
+    private final GoogleCalendarService googleCalendarService;
+
+    @PostMapping("/event")
+    public ResponseEntity<Long> createEvent(@RequestBody CalendarEventDto dto) {
+        long eventId = googleCalendarService.createEvent(dto);
+        return new ResponseEntity<>(eventId, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/event")
+    public ResponseEntity<Void> updateEvent(@RequestBody CalendarEventDto dto) {
+        googleCalendarService.update(dto);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/event/{googleEventId}")
+    public ResponseEntity<Void> deleteEvent(@PathVariable long googleEventId) {
+        googleCalendarService.delete(googleEventId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/faang/school/projectservice/controller/calendar/MeetController.java
+++ b/src/main/java/faang/school/projectservice/controller/calendar/MeetController.java
@@ -1,0 +1,99 @@
+package faang.school.projectservice.controller.calendar;
+
+import faang.school.projectservice.dto.meet.MeetDto;
+import faang.school.projectservice.dto.meet.MeetFilterDto;
+import faang.school.projectservice.service.MeetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/meets")
+@Tag(name = "Team meetings Management", description = "API for managing team meetings")
+public class MeetController {
+
+    private final MeetService meetService;
+
+    @PostMapping()
+    @Operation(summary = "Create a meet", description = "Create a new meet")
+    public MeetDto create(
+            @Parameter(description = "ID of the user", required = true)
+            @RequestHeader("x-user-id") String userId,
+            @Valid @RequestBody MeetDto meetDto) {
+        return meetService.create(meetDto);
+    }
+
+    @PutMapping("/{meetId}")
+    @Operation(summary = "Update meet", description = "Update an existing meet")
+    public MeetDto update(
+            @Parameter(description = "ID of the user", required = true)
+            @RequestHeader("x-user-id") String userId,
+            @PathVariable @NotNull long meetId,
+            @Valid @RequestBody MeetDto meetDto) {
+        return meetService.update(meetId, meetDto);
+    }
+
+    @DeleteMapping("/{meetId}")
+    @Operation(summary = "Delete a meet", description = "Delete a meet")
+    public void delete(
+            @Parameter(description = "ID of the user", required = true)
+            @RequestHeader("x-user-id") String userId,
+            @Parameter(description = "ID of the meet", required = true)
+            @PathVariable Long meetId) {
+        meetService.delete(meetId);
+    }
+
+    @PostMapping("/filter")
+    @Operation(summary = "Get meets by filter", description = "Retrieve meets by filter")
+    public List<MeetDto> getMeetsByFilter(
+            @Parameter(description = "ID of the user", required = true)
+            @RequestHeader("x-user-id") String userId,
+            @Parameter(description = "Filter for meets", required = true)
+            @RequestBody MeetFilterDto filterDto) {
+        return meetService.getByFilter(filterDto);
+    }
+
+    @GetMapping("/meets")
+    @Operation(summary = "Get all meets with pagination",
+            description = "Retrieves a list of all meets with pagination support using limit and offset.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved the list of meets"),
+            @ApiResponse(responseCode = "400", description = "Invalid pagination parameters"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public Page<MeetDto> getAllMeets(@Parameter(description = "ID of the user", required = true)
+                                     @RequestHeader("x-user-id") String userId,
+                                     @Parameter(description = "Pagination information")
+                                     Pageable pageable) {
+        return meetService.getAll(pageable);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Get an meet by ID", description = "Retrieve an meet by its ID")
+    public MeetDto getMeetById(
+            @Parameter(description = "ID of the user", required = true)
+            @RequestHeader("x-user-id") String userId,
+            @Parameter(description = "ID of the meet", required = true)
+            @PathVariable Long id) {
+        return meetService.getById(id);
+    }
+}

--- a/src/main/java/faang/school/projectservice/controller/internship/InternshipController.java
+++ b/src/main/java/faang/school/projectservice/controller/internship/InternshipController.java
@@ -1,10 +1,7 @@
 package faang.school.projectservice.controller.internship;
 
-import faang.school.projectservice.dto.internship.InternshipDto;
 import faang.school.projectservice.dto.filter.InternshipFilterDto;
-import faang.school.projectservice.exception.DataValidationException;
-import faang.school.projectservice.model.InternshipStatus;
-import faang.school.projectservice.model.TeamRole;
+import faang.school.projectservice.dto.internship.InternshipDto;
 import faang.school.projectservice.service.InternshipService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -16,20 +13,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 @RestController
 @RequiredArgsConstructor
@@ -51,18 +43,13 @@ public class InternshipController {
             @PathVariable @NotNull long id, @Valid @RequestBody InternshipDto internshipDto) {
         return internshipService.update(id, internshipDto);
     }
-//TODO переделай на POST
-    @GetMapping("/project/{projectId}")
+
+    @PostMapping("/project/{projectId}")
     @Operation(summary = "Get internships by project ID", description = "Retrieve internships by project ID with optional filtering.")
     public List<InternshipDto> getInternshipsByProject(
             @Parameter(description = "ID of the project", required = true)
             @PathVariable @NotNull Long projectId,
-            @RequestParam(required = false) InternshipStatus statusPattern,
-            @RequestParam(required = false) TeamRole rolePattern) {
-
-        InternshipFilterDto filterDto = new InternshipFilterDto();
-        filterDto.setStatusPattern(statusPattern);
-        filterDto.setRolePattern(rolePattern);
+            @Valid @RequestBody InternshipFilterDto filterDto) {
         return internshipService.getInternshipsByProjectAndFilter(projectId, filterDto);
     }
 
@@ -80,15 +67,4 @@ public class InternshipController {
             @PathVariable Long id) {
         return internshipService.getInternshipById(id);
     }
-//TODO не забудь что появился global exception handler
-    @ExceptionHandler(DataValidationException.class)
-    public String handleDataValidationException(DataValidationException ex) {
-        return ex.getMessage();
-    }
-
-    @ExceptionHandler(NoSuchElementException.class)
-    public String handleNoSuchElementException(NoSuchElementException ex) {
-        return ex.getMessage();
-    }
-
 }

--- a/src/main/java/faang/school/projectservice/controller/internship/InternshipController.java
+++ b/src/main/java/faang/school/projectservice/controller/internship/InternshipController.java
@@ -1,6 +1,6 @@
-package faang.school.projectservice.controller;
+package faang.school.projectservice.controller.internship;
 
-import faang.school.projectservice.dto.InternshipDto;
+import faang.school.projectservice.dto.internship.InternshipDto;
 import faang.school.projectservice.dto.filter.InternshipFilterDto;
 import faang.school.projectservice.exception.DataValidationException;
 import faang.school.projectservice.model.InternshipStatus;
@@ -40,21 +40,21 @@ public class InternshipController {
 
     @PostMapping()
     @Operation(summary = "Create an internship", description = "Create a new internship.")
-    public ResponseEntity<InternshipDto> create(@Valid @RequestBody InternshipDto internshipDto) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(internshipService.create(internshipDto));
+    public InternshipDto create(@Valid @RequestBody InternshipDto internshipDto) {
+        return internshipService.create(internshipDto);
     }
 
     @PutMapping("/{id}")
     @Operation(summary = "Update an internship", description = "Update an existing internship by its ID.")
-    public ResponseEntity<InternshipDto> update(
+    public InternshipDto update(
             @Parameter(description = "ID of the internship to update", required = true)
             @PathVariable @NotNull long id, @Valid @RequestBody InternshipDto internshipDto) {
-        return ResponseEntity.ok(internshipService.update(id, internshipDto));
+        return internshipService.update(id, internshipDto);
     }
-
+//TODO переделай на POST
     @GetMapping("/project/{projectId}")
     @Operation(summary = "Get internships by project ID", description = "Retrieve internships by project ID with optional filtering.")
-    public ResponseEntity<List<InternshipDto>> getInternshipsByProject(
+    public List<InternshipDto> getInternshipsByProject(
             @Parameter(description = "ID of the project", required = true)
             @PathVariable @NotNull Long projectId,
             @RequestParam(required = false) InternshipStatus statusPattern,
@@ -63,32 +63,32 @@ public class InternshipController {
         InternshipFilterDto filterDto = new InternshipFilterDto();
         filterDto.setStatusPattern(statusPattern);
         filterDto.setRolePattern(rolePattern);
-        return ResponseEntity.ok(internshipService.getInternshipsByProjectAndFilter(projectId, filterDto));
+        return internshipService.getInternshipsByProjectAndFilter(projectId, filterDto);
     }
 
     @GetMapping
     @Operation(summary = "Get all internships", description = "Retrieve all internships with pagination.")
-    public ResponseEntity<Page<InternshipDto>> getAllInternships(
+    public Page<InternshipDto> getAllInternships(
             @PageableDefault(size = 20, sort = "startDate", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok(internshipService.getAllInternships(pageable));
+        return internshipService.getAllInternships(pageable);
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "Get an internship by ID", description = "Retrieve an internship by its ID.")
-    public ResponseEntity<InternshipDto> getInternshipById(
+    public InternshipDto getInternshipById(
             @Parameter(description = "ID of the internship", required = true)
             @PathVariable Long id) {
-        return ResponseEntity.ok(internshipService.getInternshipById(id));
+        return internshipService.getInternshipById(id);
     }
-
+//TODO не забудь что появился global exception handler
     @ExceptionHandler(DataValidationException.class)
-    public ResponseEntity<String> handleDataValidationException(DataValidationException ex) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    public String handleDataValidationException(DataValidationException ex) {
+        return ex.getMessage();
     }
 
     @ExceptionHandler(NoSuchElementException.class)
-    public ResponseEntity<String> handleNoSuchElementException(NoSuchElementException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    public String handleNoSuchElementException(NoSuchElementException ex) {
+        return ex.getMessage();
     }
 
 }

--- a/src/main/java/faang/school/projectservice/dto/google/calendar/CalendarEventDto.java
+++ b/src/main/java/faang/school/projectservice/dto/google/calendar/CalendarEventDto.java
@@ -1,0 +1,24 @@
+package faang.school.projectservice.dto.google.calendar;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class CalendarEventDto {
+    private long id;
+    @NotBlank
+    private String title;
+    @NotBlank
+    private String description;
+    @NotNull
+    private LocalDateTime startDate;
+    @NotNull
+    private LocalDateTime endDate;
+
+    //TODO еще будут поля скорее всего, разберусь с этим при реализации интеграции
+}

--- a/src/main/java/faang/school/projectservice/dto/internship/InternshipDto.java
+++ b/src/main/java/faang/school/projectservice/dto/internship/InternshipDto.java
@@ -1,11 +1,10 @@
-package faang.school.projectservice.dto;
+package faang.school.projectservice.dto.internship;
 
 import faang.school.projectservice.model.InternshipStatus;
 import faang.school.projectservice.model.TeamRole;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/src/main/java/faang/school/projectservice/dto/meet/MeetDto.java
+++ b/src/main/java/faang/school/projectservice/dto/meet/MeetDto.java
@@ -1,0 +1,34 @@
+package faang.school.projectservice.dto.meet;
+
+import faang.school.projectservice.model.MeetStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@EqualsAndHashCode
+public class MeetDto {
+    private long id;
+    @NotBlank
+    private String title;
+    @NotBlank
+    private String description;
+    @NotNull
+    private LocalDateTime startDate;
+    @NotNull
+    private LocalDateTime endDate;
+    @NotNull
+    private MeetStatus status;
+    @NotNull
+    private Long creatorId;
+    @NotNull
+    private long projectId;
+    private long googleEventId;
+    private List<Long> userIds;
+}

--- a/src/main/java/faang/school/projectservice/dto/meet/MeetFilterDto.java
+++ b/src/main/java/faang/school/projectservice/dto/meet/MeetFilterDto.java
@@ -1,0 +1,18 @@
+package faang.school.projectservice.dto.meet;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class MeetFilterDto {
+    private String title;
+    private LocalDateTime startDateAfter;
+    private LocalDateTime startDateBefore;
+    private LocalDateTime endDateAfter;
+    private LocalDateTime endDateBefore;
+    private LocalDateTime createdAfter;
+    private LocalDateTime createdBefore;
+}

--- a/src/main/java/faang/school/projectservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/faang/school/projectservice/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.kms.model.AlreadyExistsException;
 import com.amazonaws.services.kms.model.NotFoundException;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.ServletException;
+import jakarta.xml.bind.ValidationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ import software.amazon.ion.NullValueException;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 @Slf4j
 @RestControllerAdvice
@@ -50,27 +52,27 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalStateException.class)
     @ResponseStatus(value = HttpStatus.CONFLICT)
-    public ErrorResponse handleAlreadyExistsException(IllegalStateException e) {
+    public ErrorResponse handleIllegalStateException(IllegalStateException e) {
         log.error("Illegal state exception occurred", e);
         return new ErrorResponse("Illegal state exception occurred", e.getMessage());
     }
 
     @ExceptionHandler(EntityNotFoundException.class)
     @ResponseStatus(value = HttpStatus.NOT_FOUND)
-    public ErrorResponse handleAlreadyExistsException(EntityNotFoundException e) {
+    public ErrorResponse handleEntityNotFoundException(EntityNotFoundException e) {
         log.error("Entity not found exception occurred", e);
         return new ErrorResponse("Entity not found exception occurred", e.getMessage());
     }
 
     @ExceptionHandler(ServletException.class)
     @ResponseStatus(value = HttpStatus.NOT_FOUND)
-    public ErrorResponse handleAlreadyExistsException(ServletException e) {
+    public ErrorResponse handleServletException(ServletException e) {
         log.error("Servlet exception occurred: ", e);
         return new ErrorResponse("Servlet exception occurred", e.getMessage());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Object> handleValidationExceptions(MethodArgumentNotValidException ex) {
+    public ResponseEntity<Object> handleMethodArgumentNotValidExceptions(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getAllErrors().forEach((error) -> {
             String fieldName = ((FieldError) error).getField();
@@ -86,6 +88,20 @@ public class GlobalExceptionHandler {
     public ErrorResponse handleException(Exception e) {
         log.error("Servlet exception occurred: ", e);
         return new ErrorResponse("Servlet exception occurred", e.getMessage());
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    @ResponseStatus(value = HttpStatus.NOT_FOUND)
+    public ErrorResponse handleNoSuchElementException(NoSuchElementException e) {
+        log.error("No such element exception occurred", e);
+        return new ErrorResponse("No such element exception occurred", e.getMessage());
+    }
+
+    @ExceptionHandler(DataValidationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleDataValidationException(DataValidationException e) {
+        log.error("Data validation exception", e);
+        return new ErrorResponse("Data validation exception", e.getMessage());
     }
 }
 

--- a/src/main/java/faang/school/projectservice/google/calendar/GoogleCalendarService.java
+++ b/src/main/java/faang/school/projectservice/google/calendar/GoogleCalendarService.java
@@ -1,0 +1,22 @@
+package faang.school.projectservice.google.calendar;
+
+import faang.school.projectservice.dto.google.calendar.CalendarEventDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GoogleCalendarService {
+
+    public long createEvent(CalendarEventDto dto) {
+        //TODO BJS2-27252
+        return 0;
+    }
+
+    public void update(CalendarEventDto dto) {
+        //TODO BJS2-27252
+    }
+
+
+    public void delete(long googleEventId) {
+        //TODO BJS2-27252
+    }
+}

--- a/src/main/java/faang/school/projectservice/jpa/MeetRepository.java
+++ b/src/main/java/faang/school/projectservice/jpa/MeetRepository.java
@@ -3,14 +3,20 @@ package faang.school.projectservice.jpa;
 import faang.school.projectservice.model.Meet;
 import faang.school.projectservice.model.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface MeetRepository extends JpaRepository<Meet, Long> {
+public interface MeetRepository extends JpaRepository<Meet, Long>, JpaSpecificationExecutor<Meet> {
 
     Optional<Meet> findByProject(Project project);
 
     Optional<Meet> findByCreatorId(long creatorId);
+
+    @Query("select m from Meet m order by m.id limit :limit offset :offset")
+    List<Meet> findAllWithLimitAndOffset(int limit, int offset);
 }

--- a/src/main/java/faang/school/projectservice/mapper/CalendarEventMapper.java
+++ b/src/main/java/faang/school/projectservice/mapper/CalendarEventMapper.java
@@ -1,0 +1,15 @@
+package faang.school.projectservice.mapper;
+
+import faang.school.projectservice.dto.google.calendar.CalendarEventDto;
+import faang.school.projectservice.dto.meet.MeetDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface CalendarEventMapper {
+
+    @Mapping(source = "googleEventId", target = "id")
+    CalendarEventDto toCalendarEventDto(MeetDto meetDto);
+}
+

--- a/src/main/java/faang/school/projectservice/mapper/MeetMapper.java
+++ b/src/main/java/faang/school/projectservice/mapper/MeetMapper.java
@@ -1,0 +1,19 @@
+package faang.school.projectservice.mapper;
+
+import faang.school.projectservice.dto.meet.MeetDto;
+import faang.school.projectservice.model.Meet;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface MeetMapper {
+
+    @Mapping(source = "project.id", target = "projectId")
+    MeetDto toDto(Meet meet);
+
+    List<MeetDto> toDtoList(List<Meet> meets);
+}
+

--- a/src/main/java/faang/school/projectservice/mapper/internship/InternshipMapper.java
+++ b/src/main/java/faang/school/projectservice/mapper/internship/InternshipMapper.java
@@ -1,6 +1,6 @@
 package faang.school.projectservice.mapper.internship;
 
-import faang.school.projectservice.dto.InternshipDto;
+import faang.school.projectservice.dto.internship.InternshipDto;
 import faang.school.projectservice.model.Internship;
 import faang.school.projectservice.model.TeamMember;
 import org.mapstruct.Mapper;

--- a/src/main/java/faang/school/projectservice/model/Meet.java
+++ b/src/main/java/faang/school/projectservice/model/Meet.java
@@ -8,6 +8,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Builder
+@AllArgsConstructor
 @Entity
 @Table(name = "meet")
 @Getter
@@ -26,6 +28,12 @@ public class Meet {
     @Column(name = "description", length = 512, nullable = false)
     private String description;
 
+    @Column(name = "start_date", columnDefinition = "TIMESTAMP")
+    private LocalDateTime startDate;
+
+    @Column(name = "end_date", columnDefinition = "TIMESTAMP")
+    private LocalDateTime endDate;
+
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
     private MeetStatus status;
@@ -33,9 +41,12 @@ public class Meet {
     @Column(name = "creator_id", nullable = false)
     private long creatorId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id")
     private Project project;
+
+    @Column(name = "google_event_id", nullable = false)
+    private long googleEventId;
 
     @ElementCollection
     @CollectionTable(name = "meet_participant", joinColumns = @JoinColumn(name = "meet_id"))

--- a/src/main/java/faang/school/projectservice/service/InternshipService.java
+++ b/src/main/java/faang/school/projectservice/service/InternshipService.java
@@ -1,6 +1,6 @@
 package faang.school.projectservice.service;
 
-import faang.school.projectservice.dto.InternshipDto;
+import faang.school.projectservice.dto.internship.InternshipDto;
 import faang.school.projectservice.dto.filter.InternshipFilterDto;
 import faang.school.projectservice.filter.internship.InternshipFilter;
 import faang.school.projectservice.jpa.TaskRepository;

--- a/src/main/java/faang/school/projectservice/service/MeetService.java
+++ b/src/main/java/faang/school/projectservice/service/MeetService.java
@@ -1,0 +1,138 @@
+package faang.school.projectservice.service;
+
+import faang.school.projectservice.config.context.UserContext;
+import faang.school.projectservice.dto.meet.MeetDto;
+import faang.school.projectservice.dto.meet.MeetFilterDto;
+import faang.school.projectservice.google.calendar.GoogleCalendarService;
+import faang.school.projectservice.jpa.MeetRepository;
+import faang.school.projectservice.mapper.CalendarEventMapper;
+import faang.school.projectservice.mapper.MeetMapper;
+import faang.school.projectservice.model.Meet;
+import faang.school.projectservice.model.MeetStatus;
+import faang.school.projectservice.model.Project;
+import faang.school.projectservice.repository.ProjectRepository;
+import faang.school.projectservice.specification.MeetSpecificationBuilder;
+import faang.school.projectservice.validator.MeetValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MeetService {
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final UserContext userContext;
+    private final MeetValidator validator;
+    private final GoogleCalendarService googleCalendarService;
+    private final MeetRepository meetRepository;
+    private final ProjectRepository projectRepository;
+    private final MeetMapper meetMapper;
+    private final CalendarEventMapper calendarEventMapper;
+
+    @Transactional
+    public MeetDto create(MeetDto meetDto) {
+        long userId = userContext.getUserId();
+        validator.validateUser(userId);
+        validator.validateUserIsCreator(userId, meetDto.getCreatorId());
+
+        Project project = projectRepository.findById(meetDto.getProjectId());
+        long googleEventId = googleCalendarService.createEvent(calendarEventMapper.toCalendarEventDto(meetDto));
+        Meet meet = buildMeet(meetDto, project, googleEventId);
+        return meetMapper.toDto(meetRepository.save(meet));
+    }
+
+    @Transactional
+    public MeetDto update(long meetId, MeetDto meetDto) {
+        long userId = userContext.getUserId();
+        validator.validateUser(userId);
+        validator.validateUserIsCreator(userId, meetDto.getCreatorId());
+        validator.validateIdFromPath(meetId, meetDto.getId());
+        Meet meet = findMeet(meetId);
+
+        meetDto.setId(meetId);
+        if (meetMapper.toDto(meet).equals(meetDto)) {
+            return meetDto;
+        }
+
+        googleCalendarService.update(calendarEventMapper.toCalendarEventDto(meetDto));
+
+        meet.setTitle(meetDto.getTitle());
+        meet.setDescription(meetDto.getDescription());
+        meet.setStartDate(meetDto.getStartDate());
+        meet.setEndDate(meetDto.getEndDate());
+        meet.setStatus(meetDto.getStatus());
+        meet.setUserIds(meetDto.getUserIds());
+        log.info(String.format("Meet id = %d, title = \"%s\" was updated at %s",
+                meetId, meetDto.getTitle(), LocalDateTime.now().format(DATE_TIME_FORMATTER)));
+        return meetMapper.toDto(meetRepository.save(meet));
+    }
+
+    @Transactional
+    public void delete(Long meetId) {
+        long userId = userContext.getUserId();
+        validator.validateUser(userId);
+
+        Meet meet = findMeet(meetId);
+        googleCalendarService.delete(meet.getGoogleEventId());
+        validator.validateUserIsCreator(userId, meet.getCreatorId());
+        meetRepository.delete(meet);
+    }
+
+    public List<MeetDto> getByFilter(MeetFilterDto filterDto) {
+        long userId = userContext.getUserId();
+        validator.validateUser(userId);
+        Specification<Meet> spec = MeetSpecificationBuilder.buildSpecification(filterDto);
+        return meetMapper.toDtoList(meetRepository.findAll(spec));
+    }
+
+    public Page<MeetDto> getAll(Pageable pageable) {
+        long userId = userContext.getUserId();
+        validator.validateUser(userId);
+        int pageSize = pageable.getPageSize();
+        int pageNumber = pageable.getPageNumber();
+        int offset = pageNumber * pageSize;
+
+        List<Meet> meets = meetRepository.findAllWithLimitAndOffset(pageSize, offset);
+        long total = meetRepository.count();
+        return new PageImpl<>(meetMapper.toDtoList(meets), pageable, total);
+    }
+
+    public MeetDto getById(Long meetId) {
+        long userId = userContext.getUserId();
+        validator.validateUser(userId);
+        Meet meet = findMeet(meetId);
+        return meetMapper.toDto(meet);
+    }
+
+    private Meet buildMeet(MeetDto meetDto, Project project, long googleEventId) {
+        return Meet.builder()
+                .title(meetDto.getTitle())
+                .description(meetDto.getDescription())
+                .startDate(meetDto.getStartDate())
+                .endDate(meetDto.getEndDate())
+                .project(project)
+                .creatorId(meetDto.getCreatorId())
+                .status(MeetStatus.PENDING)
+                .userIds(meetDto.getUserIds())
+                .googleEventId(googleEventId)
+                .build();
+    }
+
+    private Meet findMeet(long meetId) {
+        return meetRepository.findById(meetId).orElseThrow(
+                () -> new NoSuchElementException(String.format("Meet with id = %d not found", meetId)));
+    }
+}
+

--- a/src/main/java/faang/school/projectservice/specification/MeetSpecificationBuilder.java
+++ b/src/main/java/faang/school/projectservice/specification/MeetSpecificationBuilder.java
@@ -1,0 +1,43 @@
+package faang.school.projectservice.specification;
+
+import faang.school.projectservice.dto.meet.MeetFilterDto;
+import faang.school.projectservice.model.Meet;
+import org.springframework.data.jpa.domain.Specification;
+
+public class MeetSpecificationBuilder {
+
+    public static Specification<Meet> buildSpecification(MeetFilterDto meetFilterDto) {
+        Specification<Meet> spec = Specification.where(null);
+
+        if (meetFilterDto.getTitle() != null) {
+            spec = spec.and(MeetSpecifications.hasTitle(meetFilterDto.getTitle()));
+        }
+
+        if (meetFilterDto.getStartDateAfter() != null) {
+            spec = spec.and(MeetSpecifications.startDateAfter(meetFilterDto.getStartDateAfter()));
+        }
+
+        if (meetFilterDto.getStartDateBefore() != null) {
+            spec = spec.and(MeetSpecifications.startDateBefore(meetFilterDto.getStartDateBefore()));
+        }
+
+        if (meetFilterDto.getEndDateAfter() != null) {
+            spec = spec.and(MeetSpecifications.endDateAfter(meetFilterDto.getEndDateAfter()));
+        }
+
+        if (meetFilterDto.getEndDateBefore() != null) {
+            spec = spec.and(MeetSpecifications.endDateBefore(meetFilterDto.getEndDateBefore()));
+        }
+
+        if (meetFilterDto.getCreatedAfter() != null) {
+            spec = spec.and(MeetSpecifications.createdAfter(meetFilterDto.getCreatedAfter()));
+        }
+
+        if (meetFilterDto.getCreatedBefore() != null) {
+            spec = spec.and(MeetSpecifications.createdBefore(meetFilterDto.getCreatedBefore()));
+        }
+
+        return spec;
+    }
+}
+

--- a/src/main/java/faang/school/projectservice/specification/MeetSpecifications.java
+++ b/src/main/java/faang/school/projectservice/specification/MeetSpecifications.java
@@ -1,0 +1,45 @@
+package faang.school.projectservice.specification;
+
+import faang.school.projectservice.model.Meet;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+
+public class MeetSpecifications {
+
+    public static Specification<Meet> hasTitle(String title) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.like(root.get("title"), "%" + title + "%");
+    }
+
+    public static Specification<Meet> startDateAfter(LocalDateTime date) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.greaterThanOrEqualTo(root.get("startDate"), date);
+    }
+
+    public static Specification<Meet> startDateBefore(LocalDateTime date) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.lessThanOrEqualTo(root.get("startDate"), date);
+    }
+
+    public static Specification<Meet> endDateAfter(LocalDateTime date) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.greaterThanOrEqualTo(root.get("endDate"), date);
+    }
+
+    public static Specification<Meet> endDateBefore(LocalDateTime date) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.lessThanOrEqualTo(root.get("endDate"), date);
+    }
+
+    public static Specification<Meet> createdAfter(LocalDateTime date) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.greaterThanOrEqualTo(root.get("createdAt"), date);
+    }
+
+    public static Specification<Meet> createdBefore(LocalDateTime date) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.lessThanOrEqualTo(root.get("createdAt"), date);
+    }
+}
+

--- a/src/main/java/faang/school/projectservice/validator/MeetValidator.java
+++ b/src/main/java/faang/school/projectservice/validator/MeetValidator.java
@@ -1,0 +1,35 @@
+package faang.school.projectservice.validator;
+
+import faang.school.projectservice.client.UserServiceClient;
+import faang.school.projectservice.dto.client.UserDto;
+import faang.school.projectservice.exception.DataValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class MeetValidator {
+    private final UserServiceClient userServiceClient;
+
+    public void validateUser(long userId) {
+        if (userId <= 0) {
+            throw new DataValidationException(String.format("User's id can't be equal %d", userId));
+        }
+        UserDto user = userServiceClient.getUser(userId);
+        if (user == null) {
+            throw new DataValidationException(String.format("The user must exist in the system, userId = %d", userId));
+        }
+    }
+
+    public void validateUserIsCreator(long userId, long creatorId) {
+        if (userId != creatorId) {
+            throw new DataValidationException("The meeting creator's ID does not match the user's ID");
+        }
+    }
+
+    public void validateIdFromPath(long id, Long meetDtoId) {
+        if (meetDtoId != null && meetDtoId != id) {
+            throw new DataValidationException("The ID in the path must match the ID in the DTO");
+        }
+    }
+}

--- a/src/main/resources/db/changelog/changeset/project_V017_meet.sql
+++ b/src/main/resources/db/changelog/changeset/project_V017_meet.sql
@@ -1,0 +1,4 @@
+ALTER TABLE meet
+ADD COLUMN start_date timestamptz NOT NULL,
+ADD COLUMN end_date timestamptz NOT NULL,
+ADD COLUMN google_event_id BIGINT NOT NULL;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -25,3 +25,5 @@ databaseChangeLog:
       file: db/changelog/changeset/project_V015_resource_roles.sql
   - include:
       file: db/changelog/changeset/project_V016_meet.sql
+  - include:
+      file: db/changelog/changeset/project_V017_meet.sql

--- a/src/test/java/faang/school/projectservice/internship/InternshipControllerTest.java
+++ b/src/test/java/faang/school/projectservice/internship/InternshipControllerTest.java
@@ -1,8 +1,8 @@
 package faang.school.projectservice.internship;
 
-import faang.school.projectservice.controller.InternshipController;
-import faang.school.projectservice.dto.InternshipDto;
+import faang.school.projectservice.controller.internship.InternshipController;
 import faang.school.projectservice.dto.filter.InternshipFilterDto;
+import faang.school.projectservice.dto.internship.InternshipDto;
 import faang.school.projectservice.exception.DataValidationException;
 import faang.school.projectservice.model.InternshipStatus;
 import faang.school.projectservice.model.TeamRole;
@@ -16,8 +16,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,10 +48,9 @@ class InternshipControllerTest {
         internshipDto.setId(1L);
         when(internshipService.create(any(InternshipDto.class))).thenReturn(internshipDto);
 
-        ResponseEntity<InternshipDto> response = internshipController.create(new InternshipDto());
+        InternshipDto savedInternshipDto = internshipController.create(new InternshipDto());
 
-        assertEquals(HttpStatus.CREATED, response.getStatusCode());
-        assertEquals(internshipDto, response.getBody());
+        assertEquals(internshipDto, savedInternshipDto);
         verify(internshipService, times(1)).create(any(InternshipDto.class));
     }
 
@@ -63,10 +60,9 @@ class InternshipControllerTest {
         internshipDto.setId(1L);
         when(internshipService.update(anyLong(), any(InternshipDto.class))).thenReturn(internshipDto);
 
-        ResponseEntity<InternshipDto> response = internshipController.update(1L, new InternshipDto());
+        InternshipDto updatedInternshipDto = internshipController.update(1L, new InternshipDto());
 
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(internshipDto, response.getBody());
+        assertEquals(internshipDto, updatedInternshipDto);
         verify(internshipService, times(1)).update(anyLong(), any(InternshipDto.class));
     }
 
@@ -77,10 +73,9 @@ class InternshipControllerTest {
         when(internshipService.getInternshipsByProjectAndFilter(anyLong(), any(InternshipFilterDto.class)))
                 .thenReturn(Collections.singletonList(internshipDto));
 
-        ResponseEntity<List<InternshipDto>> response = internshipController.getInternshipsByProject(1L, InternshipStatus.IN_PROGRESS, TeamRole.INTERN);
+        List<InternshipDto> internshipDtoList = internshipController.getInternshipsByProject(1L, InternshipStatus.IN_PROGRESS, TeamRole.INTERN);
 
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(1, response.getBody().size());
+        assertEquals(1, internshipDtoList.size());
         verify(internshipService, times(1)).getInternshipsByProjectAndFilter(anyLong(), any(InternshipFilterDto.class));
     }
 
@@ -91,10 +86,9 @@ class InternshipControllerTest {
         Page<InternshipDto> page = new PageImpl<>(Arrays.asList(internshipDto));
         when(internshipService.getAllInternships(any(Pageable.class))).thenReturn(page);
 
-        ResponseEntity<Page<InternshipDto>> response = internshipController.getAllInternships(PageRequest.of(0, 10));
+        Page<InternshipDto> internshipDtoPage = internshipController.getAllInternships(PageRequest.of(0, 10));
 
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(1, response.getBody().getTotalElements());
+        assertEquals(1, internshipDtoPage.getTotalElements());
         verify(internshipService, times(1)).getAllInternships(any(Pageable.class));
     }
 
@@ -104,10 +98,9 @@ class InternshipControllerTest {
         internshipDto.setId(1L);
         when(internshipService.getInternshipById(anyLong())).thenReturn(internshipDto);
 
-        ResponseEntity<InternshipDto> response = internshipController.getInternshipById(1L);
+        InternshipDto internshipById = internshipController.getInternshipById(1L);
 
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(internshipDto, response.getBody());
+        assertEquals(internshipDto, internshipById);
         verify(internshipService, times(1)).getInternshipById(anyLong());
     }
 
@@ -115,20 +108,18 @@ class InternshipControllerTest {
     void testHandleDataValidationException_ShouldReturnBadRequest() {
         DataValidationException exception = new DataValidationException("Validation error");
 
-        ResponseEntity<String> response = internshipController.handleDataValidationException(exception);
+        String handlerResponse = internshipController.handleDataValidationException(exception);
 
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertEquals("Validation error", response.getBody());
+        assertEquals("Validation error", handlerResponse);
     }
 
     @Test
     void testHandleNoSuchElementException_ShouldReturnNotFound() {
         NoSuchElementException exception = new NoSuchElementException("Element not found");
 
-        ResponseEntity<String> response = internshipController.handleNoSuchElementException(exception);
+        String handlerResponse = internshipController.handleNoSuchElementException(exception);
 
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        assertEquals("Element not found", response.getBody());
+        assertEquals("Element not found", handlerResponse);
     }
 }
 

--- a/src/test/java/faang/school/projectservice/internship/InternshipControllerTest.java
+++ b/src/test/java/faang/school/projectservice/internship/InternshipControllerTest.java
@@ -3,7 +3,6 @@ package faang.school.projectservice.internship;
 import faang.school.projectservice.controller.internship.InternshipController;
 import faang.school.projectservice.dto.filter.InternshipFilterDto;
 import faang.school.projectservice.dto.internship.InternshipDto;
-import faang.school.projectservice.exception.DataValidationException;
 import faang.school.projectservice.model.InternshipStatus;
 import faang.school.projectservice.model.TeamRole;
 import faang.school.projectservice.service.InternshipService;
@@ -20,7 +19,6 @@ import org.springframework.data.domain.Pageable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -73,7 +71,11 @@ class InternshipControllerTest {
         when(internshipService.getInternshipsByProjectAndFilter(anyLong(), any(InternshipFilterDto.class)))
                 .thenReturn(Collections.singletonList(internshipDto));
 
-        List<InternshipDto> internshipDtoList = internshipController.getInternshipsByProject(1L, InternshipStatus.IN_PROGRESS, TeamRole.INTERN);
+        InternshipFilterDto filterDto = new InternshipFilterDto();
+        filterDto.setRolePattern(TeamRole.INTERN);
+        filterDto.setStatusPattern(InternshipStatus.IN_PROGRESS);
+
+        List<InternshipDto> internshipDtoList = internshipController.getInternshipsByProject(1L, filterDto);
 
         assertEquals(1, internshipDtoList.size());
         verify(internshipService, times(1)).getInternshipsByProjectAndFilter(anyLong(), any(InternshipFilterDto.class));
@@ -102,24 +104,6 @@ class InternshipControllerTest {
 
         assertEquals(internshipDto, internshipById);
         verify(internshipService, times(1)).getInternshipById(anyLong());
-    }
-
-    @Test
-    void testHandleDataValidationException_ShouldReturnBadRequest() {
-        DataValidationException exception = new DataValidationException("Validation error");
-
-        String handlerResponse = internshipController.handleDataValidationException(exception);
-
-        assertEquals("Validation error", handlerResponse);
-    }
-
-    @Test
-    void testHandleNoSuchElementException_ShouldReturnNotFound() {
-        NoSuchElementException exception = new NoSuchElementException("Element not found");
-
-        String handlerResponse = internshipController.handleNoSuchElementException(exception);
-
-        assertEquals("Element not found", handlerResponse);
     }
 }
 

--- a/src/test/java/faang/school/projectservice/internship/InternshipMapperTest.java
+++ b/src/test/java/faang/school/projectservice/internship/InternshipMapperTest.java
@@ -1,6 +1,6 @@
 package faang.school.projectservice.internship;
 
-import faang.school.projectservice.dto.InternshipDto;
+import faang.school.projectservice.dto.internship.InternshipDto;
 import faang.school.projectservice.mapper.internship.InternshipMapper;
 import faang.school.projectservice.model.Internship;
 import faang.school.projectservice.model.Project;

--- a/src/test/java/faang/school/projectservice/internship/InternshipServiceTest.java
+++ b/src/test/java/faang/school/projectservice/internship/InternshipServiceTest.java
@@ -1,6 +1,6 @@
 package faang.school.projectservice.internship;
 
-import faang.school.projectservice.dto.InternshipDto;
+import faang.school.projectservice.dto.internship.InternshipDto;
 import faang.school.projectservice.dto.filter.InternshipFilterDto;
 import faang.school.projectservice.filter.internship.InternshipStatusFilter;
 import faang.school.projectservice.filter.internship.InternshipTeamRoleFilter;

--- a/src/test/java/faang/school/projectservice/meet/MeetMapperTest.java
+++ b/src/test/java/faang/school/projectservice/meet/MeetMapperTest.java
@@ -1,0 +1,124 @@
+package faang.school.projectservice.meet;
+
+import faang.school.projectservice.dto.meet.MeetDto;
+import faang.school.projectservice.mapper.MeetMapper;
+import faang.school.projectservice.model.Meet;
+import faang.school.projectservice.model.MeetStatus;
+import faang.school.projectservice.model.Project;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class MeetMapperTest {
+
+    private MeetMapper meetMapper;
+
+    @BeforeEach
+    void setUp() {
+        meetMapper = Mappers.getMapper(MeetMapper.class);
+    }
+
+    @Test
+    void testToDto_ShouldMapMeetToMeetDto() {
+        Meet meet = new Meet();
+        meet.setId(1L);
+        meet.setTitle("Test Title");
+        meet.setDescription("Test Description");
+        meet.setStartDate(LocalDateTime.of(2023, 9, 27, 10, 0));
+        meet.setEndDate(LocalDateTime.of(2023, 9, 27, 12, 0));
+        meet.setStatus(MeetStatus.PENDING);
+        meet.setCreatorId(100L);
+        meet.setGoogleEventId(500L);
+
+        Project project = new Project();
+        project.setId(200L);
+        meet.setProject(project);
+
+        meet.setUserIds(Arrays.asList(1L, 2L, 3L));
+
+        MeetDto meetDto = meetMapper.toDto(meet);
+
+        assertNotNull(meetDto);
+        assertEquals(1L, meetDto.getId());
+        assertEquals("Test Title", meetDto.getTitle());
+        assertEquals("Test Description", meetDto.getDescription());
+        assertEquals(LocalDateTime.of(2023, 9, 27, 10, 0), meetDto.getStartDate());
+        assertEquals(LocalDateTime.of(2023, 9, 27, 12, 0), meetDto.getEndDate());
+        assertEquals(MeetStatus.PENDING, meetDto.getStatus());
+        assertEquals(100L, meetDto.getCreatorId());
+        assertEquals(500L, meetDto.getGoogleEventId());
+        assertEquals(200L, meetDto.getProjectId());
+        assertEquals(Arrays.asList(1L, 2L, 3L), meetDto.getUserIds());
+    }
+
+    @Test
+    void testToDtoList_ShouldMapListOfMeetToListOfMeetDto() {
+        Meet meet1 = new Meet();
+        meet1.setId(1L);
+        meet1.setTitle("Test Title 1");
+        meet1.setDescription("Test Description 1");
+        meet1.setStartDate(LocalDateTime.of(2023, 9, 27, 10, 0));
+        meet1.setEndDate(LocalDateTime.of(2023, 9, 27, 12, 0));
+        meet1.setStatus(MeetStatus.PENDING);
+        meet1.setCreatorId(100L);
+        meet1.setGoogleEventId(500L);
+
+        Project project1 = new Project();
+        project1.setId(200L);
+        meet1.setProject(project1);
+        meet1.setUserIds(Arrays.asList(1L, 2L));
+
+        Meet meet2 = new Meet();
+        meet2.setId(2L);
+        meet2.setTitle("Test Title 2");
+        meet2.setDescription("Test Description 2");
+        meet2.setStartDate(LocalDateTime.of(2023, 9, 28, 10, 0));
+        meet2.setEndDate(LocalDateTime.of(2023, 9, 28, 12, 0));
+        meet2.setStatus(MeetStatus.COMPLETED);
+        meet2.setCreatorId(101L);
+        meet2.setGoogleEventId(501L);
+
+        Project project2 = new Project();
+        project2.setId(201L);
+        meet2.setProject(project2);
+        meet2.setUserIds(Arrays.asList(3L, 4L));
+
+        List<Meet> meets = Arrays.asList(meet1, meet2);
+
+        List<MeetDto> meetDtos = meetMapper.toDtoList(meets);
+
+        assertNotNull(meetDtos);
+        assertEquals(2, meetDtos.size());
+
+        MeetDto meetDto1 = meetDtos.get(0);
+        assertEquals(1L, meetDto1.getId());
+        assertEquals("Test Title 1", meetDto1.getTitle());
+        assertEquals("Test Description 1", meetDto1.getDescription());
+        assertEquals(LocalDateTime.of(2023, 9, 27, 10, 0), meetDto1.getStartDate());
+        assertEquals(LocalDateTime.of(2023, 9, 27, 12, 0), meetDto1.getEndDate());
+        assertEquals(MeetStatus.PENDING, meetDto1.getStatus());
+        assertEquals(100L, meetDto1.getCreatorId());
+        assertEquals(500L, meetDto1.getGoogleEventId());
+        assertEquals(200L, meetDto1.getProjectId());
+        assertEquals(Arrays.asList(1L, 2L), meetDto1.getUserIds());
+
+        MeetDto meetDto2 = meetDtos.get(1);
+        assertEquals(2L, meetDto2.getId());
+        assertEquals("Test Title 2", meetDto2.getTitle());
+        assertEquals("Test Description 2", meetDto2.getDescription());
+        assertEquals(LocalDateTime.of(2023, 9, 28, 10, 0), meetDto2.getStartDate());
+        assertEquals(LocalDateTime.of(2023, 9, 28, 12, 0), meetDto2.getEndDate());
+        assertEquals(MeetStatus.COMPLETED, meetDto2.getStatus());
+        assertEquals(101L, meetDto2.getCreatorId());
+        assertEquals(501L, meetDto2.getGoogleEventId());
+        assertEquals(201L, meetDto2.getProjectId());
+        assertEquals(Arrays.asList(3L, 4L), meetDto2.getUserIds());
+    }
+}

--- a/src/test/java/faang/school/projectservice/meet/MeetServiceTest.java
+++ b/src/test/java/faang/school/projectservice/meet/MeetServiceTest.java
@@ -1,0 +1,311 @@
+package faang.school.projectservice.meet;
+
+import faang.school.projectservice.config.context.UserContext;
+import faang.school.projectservice.dto.meet.MeetDto;
+import faang.school.projectservice.dto.meet.MeetFilterDto;
+import faang.school.projectservice.google.calendar.GoogleCalendarService;
+import faang.school.projectservice.jpa.MeetRepository;
+import faang.school.projectservice.mapper.CalendarEventMapper;
+import faang.school.projectservice.mapper.MeetMapper;
+import faang.school.projectservice.model.Meet;
+import faang.school.projectservice.model.Project;
+import faang.school.projectservice.repository.ProjectRepository;
+import faang.school.projectservice.service.MeetService;
+import faang.school.projectservice.validator.MeetValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MeetServiceTest {
+
+    @InjectMocks
+    private MeetService meetService;
+
+    @Mock
+    private MeetRepository meetRepository;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Mock
+    private GoogleCalendarService googleCalendarService;
+
+    @Mock
+    private MeetMapper meetMapper;
+
+    @Mock
+    private CalendarEventMapper calendarEventMapper;
+
+    @Mock
+    private MeetValidator meetValidator;
+
+    @Mock
+    private UserContext userContext;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testCreateMeet() {
+        MeetDto meetDto = new MeetDto();
+        meetDto.setCreatorId(1L);
+        meetDto.setProjectId(1L);
+
+        Project project = new Project();
+        long googleEventId = 123L;
+
+        when(projectRepository.findById(meetDto.getProjectId())).thenReturn(project);
+        when(googleCalendarService.createEvent(any())).thenReturn(googleEventId);
+        when(meetRepository.save(any(Meet.class))).thenReturn(new Meet());
+        when(userContext.getUserId()).thenReturn(1L);
+
+        meetService.create(meetDto);
+
+        verify(meetValidator).validateUser(anyLong());
+        verify(meetValidator).validateUserIsCreator(anyLong(), anyLong());
+        verify(meetRepository).save(any(Meet.class));
+    }
+
+    @Test
+    void testUpdate_WhenAllFieldsTheSame() {
+        long meetId = 1L;
+        MeetDto meetDto = new MeetDto();
+        meetDto.setId(meetId);
+        meetDto.setCreatorId(1L);
+        meetDto.setTitle("Title");
+
+        Meet meet = new Meet();
+        meet.setId(meetId);
+        meet.setCreatorId(1L);
+        meet.setTitle("Title");
+        when(meetRepository.findById(meetId)).thenReturn(Optional.of(meet));
+        when(meetMapper.toDto(meet)).thenReturn(meetDto);
+        when(userContext.getUserId()).thenReturn(1L);
+
+        meetService.update(meetId, meetDto);
+
+        verify(meetValidator).validateUser(anyLong());
+        verify(meetValidator).validateUserIsCreator(anyLong(), anyLong());
+        verify(meetValidator).validateIdFromPath(anyLong(), anyLong());
+
+        verify(googleCalendarService, never()).update(any());
+        verify(meetRepository, never()).save(any(Meet.class));
+    }
+
+    @Test
+    void testUpdate_WhenAllFieldsDifferent() {
+        long meetId = 1L;
+        MeetDto meetDto = new MeetDto();
+        meetDto.setId(meetId);
+        meetDto.setCreatorId(1L);
+        meetDto.setTitle("New title");
+
+        Meet meet = new Meet();
+        meet.setId(meetId);
+        meet.setCreatorId(1L);
+        meet.setTitle("Old title");
+        MeetDto oldMeetDto = new MeetDto();
+        oldMeetDto.setId(meetId);
+        oldMeetDto.setCreatorId(1L);
+        oldMeetDto.setTitle("Old title");
+        when(meetRepository.findById(meetId)).thenReturn(Optional.of(meet));
+        when(meetMapper.toDto(meet)).thenReturn(oldMeetDto);
+        when(userContext.getUserId()).thenReturn(1L);
+
+        meetService.update(meetId, meetDto);
+
+        verify(meetValidator).validateUser(anyLong());
+        verify(meetValidator).validateUserIsCreator(anyLong(), anyLong());
+        verify(meetValidator).validateIdFromPath(anyLong(), anyLong());
+
+        verify(googleCalendarService).update(any());
+        verify(meetRepository).save(any(Meet.class));
+    }
+
+    @Test
+    void testDelete() {
+        long meetId = 1L;
+        Meet meet = new Meet();
+        meet.setCreatorId(1L);
+
+        when(meetRepository.findById(meetId)).thenReturn(Optional.of(meet));
+        when(userContext.getUserId()).thenReturn(1L);
+
+        meetService.delete(meetId);
+
+        verify(meetValidator).validateUser(anyLong());
+        verify(meetValidator).validateUserIsCreator(anyLong(), anyLong());
+        verify(googleCalendarService).delete(meet.getGoogleEventId());
+        verify(meetRepository).delete(meet);
+    }
+
+    @Test
+    void testDelete_WhenMeetNotFound() {
+        long meetId = 1L;
+        Meet meet = new Meet();
+        meet.setCreatorId(1L);
+
+        when(meetRepository.findById(meetId)).thenReturn(Optional.empty());
+        when(userContext.getUserId()).thenReturn(1L);
+
+        assertThrows(NoSuchElementException.class, () -> meetService.delete(meetId));
+    }
+
+    @Test
+    void testGetById() {
+        long meetId = 1L;
+        Meet meet = new Meet();
+        MeetDto meetDto = new MeetDto();
+
+        when(meetRepository.findById(meetId)).thenReturn(Optional.of(meet));
+        when(meetMapper.toDto(meet)).thenReturn(meetDto);
+        when(userContext.getUserId()).thenReturn(1L);
+
+        MeetDto result = meetService.getById(meetId);
+
+        assertEquals(meetDto, result);
+        verify(meetValidator).validateUser(anyLong());
+        verify(meetRepository).findById(meetId);
+    }
+
+    @Test
+    void testGetById_WhenMeetNotFound() {
+        long meetId = 1L;
+        Meet meet = new Meet();
+        MeetDto meetDto = new MeetDto();
+
+        when(meetRepository.findById(meetId)).thenReturn(Optional.empty());
+        when(meetMapper.toDto(meet)).thenReturn(meetDto);
+        when(userContext.getUserId()).thenReturn(1L);
+
+        assertThrows(NoSuchElementException.class, () -> meetService.getById(meetId));
+    }
+
+    @Test
+    void testGetAll() {
+        Pageable pageable = PageRequest.of(0, 10);
+        List<Meet> meets = Collections.singletonList(new Meet());
+        Page<Meet> meetPage = new PageImpl<>(meets, pageable, meets.size());
+
+        when(meetRepository.findAllWithLimitAndOffset(anyInt(), anyInt())).thenReturn(meets);
+        when(meetMapper.toDtoList(meets)).thenReturn(Collections.singletonList(new MeetDto()));
+        when(userContext.getUserId()).thenReturn(1L);
+
+        Page<MeetDto> result = meetService.getAll(pageable);
+
+        assertNotNull(result);
+        verify(meetValidator).validateUser(anyLong());
+        verify(meetRepository).findAllWithLimitAndOffset(anyInt(), anyInt());
+    }
+
+    @Test
+    void testUpdate_WhenMeetNotFound() {
+        long meetId = 1L;
+        MeetDto meetDto = new MeetDto();
+        meetDto.setId(meetId);
+        meetDto.setCreatorId(1L);
+        meetDto.setTitle("New title");
+
+        Meet meet = new Meet();
+        meet.setId(meetId);
+        meet.setCreatorId(1L);
+        meet.setTitle("Old title");
+        MeetDto oldMeetDto = new MeetDto();
+        oldMeetDto.setId(meetId);
+        oldMeetDto.setCreatorId(1L);
+        oldMeetDto.setTitle("Old title");
+        when(meetRepository.findById(meetId)).thenReturn(Optional.empty());
+        when(meetMapper.toDto(meet)).thenReturn(oldMeetDto);
+        when(userContext.getUserId()).thenReturn(1L);
+
+        assertThrows(NoSuchElementException.class, () -> meetService.update(meetId, meetDto));
+    }
+
+    @Test
+    void getByFilterSuccess() {
+        MeetFilterDto filterDto = new MeetFilterDto();
+        filterDto.setTitle("Meeting");
+        filterDto.setStartDateAfter(LocalDateTime.of(2024, 9, 27, 0, 0));
+
+        Meet meet = new Meet();
+        List<Meet> meetList = Collections.singletonList(meet);
+        List<MeetDto> meetDtoList = Collections.singletonList(new MeetDto());
+
+        when(meetRepository.findAll(any(Specification.class))).thenReturn(meetList);
+        when(meetMapper.toDtoList(meetList)).thenReturn(meetDtoList);
+        when(userContext.getUserId()).thenReturn(1L);
+
+        List<MeetDto> result = meetService.getByFilter(filterDto);
+
+        verify(meetRepository).findAll(any(Specification.class));
+
+        assertEquals(meetDtoList, result);
+    }
+
+    @Test
+    void getByFilterWithNoCriteria() {
+        MeetFilterDto filterDto = new MeetFilterDto();
+
+        Meet meet = new Meet();
+        List<Meet> meetList = Collections.singletonList(meet);
+        List<MeetDto> meetDtoList = Collections.singletonList(new MeetDto());
+
+        when(meetRepository.findAll(any(Specification.class))).thenReturn(meetList);
+        when(meetMapper.toDtoList(meetList)).thenReturn(meetDtoList);
+        when(userContext.getUserId()).thenReturn(1L);
+
+        List<MeetDto> result = meetService.getByFilter(filterDto);
+
+        verify(meetRepository).findAll(any(Specification.class));
+
+        assertEquals(meetDtoList, result);
+    }
+
+    @Test
+    void getByFilterWithMultipleCriteria() {
+        MeetFilterDto filterDto = new MeetFilterDto();
+        filterDto.setTitle("Team Sync");
+        filterDto.setStartDateAfter(LocalDateTime.of(2024, 9, 1, 0, 0));
+        filterDto.setStartDateBefore(LocalDateTime.of(2024, 10, 1, 0, 0));
+
+        Meet meet = new Meet();
+        List<Meet> meetList = Collections.singletonList(meet);
+        List<MeetDto> meetDtoList = Collections.singletonList(new MeetDto());
+
+        when(meetRepository.findAll(any(Specification.class))).thenReturn(meetList);
+        when(meetMapper.toDtoList(meetList)).thenReturn(meetDtoList);
+        when(userContext.getUserId()).thenReturn(1L);
+
+        List<MeetDto> result = meetService.getByFilter(filterDto);
+
+        verify(meetRepository).findAll(any(Specification.class));
+
+        assertEquals(meetDtoList, result);
+    }
+
+}

--- a/src/test/java/faang/school/projectservice/meet/MeetSpecificationBuilderTest.java
+++ b/src/test/java/faang/school/projectservice/meet/MeetSpecificationBuilderTest.java
@@ -1,0 +1,107 @@
+package faang.school.projectservice.meet;
+
+import faang.school.projectservice.dto.meet.MeetFilterDto;
+import faang.school.projectservice.model.Meet;
+import faang.school.projectservice.specification.MeetSpecificationBuilder;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MeetSpecificationBuilderTest {
+
+    @Test
+    void buildSpecification_WithTitleFilter() {
+        MeetFilterDto filterDto = new MeetFilterDto();
+        filterDto.setTitle("Team Meeting");
+
+        Root<Meet> root = mock(Root.class);
+        CriteriaQuery<?> query = mock(CriteriaQuery.class);
+        CriteriaBuilder criteriaBuilder = mock(CriteriaBuilder.class);
+        Predicate predicate = mock(Predicate.class);
+
+        when(criteriaBuilder.like(any(), anyString())).thenReturn(predicate);
+        when(root.get("title")).thenReturn(Mockito.mock(Path.class));
+
+        Specification<Meet> specification = MeetSpecificationBuilder.buildSpecification(filterDto);
+
+        Predicate resultPredicate = specification.toPredicate(root, query, criteriaBuilder);
+
+        verify(criteriaBuilder, times(1)).like(any(), eq("%Team Meeting%"));
+        assertNotNull(resultPredicate);
+    }
+
+    @Test
+    void buildSpecification_WithDateRange() {
+        MeetFilterDto filterDto = new MeetFilterDto();
+        LocalDateTime startDateAfter = LocalDateTime.of(2024, 9, 1, 0, 0);
+        filterDto.setStartDateAfter(startDateAfter);
+        LocalDateTime endDateBefore = LocalDateTime.of(2024, 10, 1, 0, 0);
+        filterDto.setEndDateBefore(endDateBefore);
+
+        Root<Meet> root = mock(Root.class);
+        CriteriaQuery<?> query = mock(CriteriaQuery.class);
+        CriteriaBuilder criteriaBuilder = mock(CriteriaBuilder.class);
+        Predicate predicate = mock(Predicate.class);
+
+        when(criteriaBuilder.greaterThanOrEqualTo(any(), any(LocalDateTime.class))).thenReturn(predicate);
+        when(criteriaBuilder.lessThanOrEqualTo(root.get("endDate"), endDateBefore)).thenReturn(predicate);
+        when(root.get("title")).thenReturn(Mockito.mock(Path.class));
+        when(root.get("startDate")).thenReturn(Mockito.mock(Path.class));
+        when(root.get("endDate")).thenReturn(Mockito.mock(Path.class));
+
+        Specification<Meet> specification = MeetSpecificationBuilder.buildSpecification(filterDto);
+
+        Predicate resultPredicate = specification.toPredicate(root, query, criteriaBuilder);
+
+        verify(criteriaBuilder, times(1)).greaterThanOrEqualTo(any(), eq(startDateAfter));
+        verify(criteriaBuilder, times(1)).lessThanOrEqualTo(any(), eq(endDateBefore));
+        assertNotNull(resultPredicate);
+    }
+
+    @Test
+    void buildSpecification_WithMultipleFilters() {
+        MeetFilterDto filterDto = new MeetFilterDto();
+        filterDto.setTitle("Sync");
+        LocalDateTime startDateAfter = LocalDateTime.of(2024, 9, 1, 0, 0);
+        filterDto.setStartDateAfter(startDateAfter);
+        LocalDateTime endDateBefore = LocalDateTime.of(2024, 10, 1, 0, 0);
+        filterDto.setEndDateBefore(endDateBefore);
+
+        Root<Meet> root = mock(Root.class);
+        CriteriaQuery<?> query = mock(CriteriaQuery.class);
+        CriteriaBuilder criteriaBuilder = mock(CriteriaBuilder.class);
+        Predicate predicate = mock(Predicate.class);
+
+        when(criteriaBuilder.like(any(), anyString())).thenReturn(predicate);
+        when(criteriaBuilder.greaterThanOrEqualTo(root.get("startDate"), startDateAfter)).thenReturn(predicate);
+        when(criteriaBuilder.lessThanOrEqualTo(root.get("endDate"), endDateBefore)).thenReturn(predicate);
+        when(root.get("title")).thenReturn(Mockito.mock(Path.class));
+        when(root.get("startDate")).thenReturn(Mockito.mock(Path.class));
+        when(root.get("endDate")).thenReturn(Mockito.mock(Path.class));
+
+        Specification<Meet> specification = MeetSpecificationBuilder.buildSpecification(filterDto);
+
+        Predicate resultPredicate = specification.toPredicate(root, query, criteriaBuilder);
+
+        verify(criteriaBuilder, times(1)).like(any(), eq("%Sync%"));
+        verify(criteriaBuilder, times(1)).greaterThanOrEqualTo(any(), eq(startDateAfter));
+        verify(criteriaBuilder, times(1)).lessThanOrEqualTo(any(), eq(endDateBefore));
+        assertNotNull(resultPredicate);
+    }
+}


### PR DESCRIPTION
В entity Meet над полем Prooject добавил fetchType LAZY, потому что когда я доставал запись у меня вытаскивалась и Project, хотя она мне не нужна, нужен только ее id. А запись project вытаскивается очень страшно, там миллион join-ов и миллиард полей вытаскивается. Интеграцию с google календарем еще не сделал, буду делать в рамках другой задачи, как и задумано. В этой задаче сделал контроллер с сервисом для этих целей. Методы сервиса пока просто заглушки. Обращают внутри project-service напрямую к этому сервису. Контроллер сделал, чтобы другие сервисы могли общаться с google календарем через feign client. Например, в user-service есть entity Event, которая аналогична entity Meet в project-service. Влад писал в разделе help, что Event для более глобальных мероприятий, а Meet для встреч команды и обсуждения вопросов по проекту. В других командах, насколько я понял, эту же задачу ребята могут решать  по-другому. Студент с ником Vanchous, как я понял, пишет все в таблицу еvent, обращаясь для этого через feign клиент в user-service. При этом meet остается незадействованным. Ну судя по условию нашей задачи, мы должны работать именно с таблицей meet