### PR TITLE
BJS2-66841: CI pipeline для project_service

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+name: CI pipeline
+
+on:
+  pull_request:
+    branches:
+      - medusa-master-stream9
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Test with Gradle
+        run: ./gradlew test -x testClasses --no-daemon --continue

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Set up Gradle


### PR DESCRIPTION
jira: https://faang-school.atlassian.net/browse/BJS2-66841

Условия задачи
В git-репозитории project_service подключить и настроить CI-пайплайн.

CI (Continuous Integration) пайплайны в GitHub представляют собой автоматизированный процесс, который выполняется каждый раз при внесении изменений в репозиторий. Они играют важную роль в разработке программного обеспечения и обладают следующими преимуществами:

Автоматическая сборка и тестирование.
Уверенность в качестве кода.

Ускорение процесса разработки.

Безопасность и стабильность.

Документирование и трассировка.

Задача:

Добавить в корень проекта директорию .github/workflows .

Внутри создать файл ci.yml .

Настроить джобу, которая будет запускать тесты при создании пулл-реквеста в ветку dev .

Провести демо для коллег, на котором рассказать, какие возможности предоставляют пайплайны GitHub, возможном применении и бонусах, которые разработчик (и не только) получает при их использовании.

Порядок выполнения:

Сначала протестировать работу пайплайна на новых ветках: создать из ветки dev ветки feature/pipline-BC-tasknumber и feature/pipeline-test-BC-tasknumber.

Выполнить работу в ветке feature/pipline-BC-tasknumber с настройкой проверки тестов при пулл-реквесте в эту ветку, запушить.

Создать в в ветке feature/pipeline-test-BC-tasknumber тест, который должен упасть (можно использовать fail()), запушить и создать пулл-реквест в ветку feature/pipline-BC-tasknumber .

Отладить при необходимости.

Когда пайплайн заработает, создать пулл-реквест с конфигурацией в ветку dev .

Ссылка на полезные материал: [Creating a CI/CD pipeline using Github Actions](https://medium.com/@michaelekpang/creating-a-ci-cd-pipeline-using-github-actions-b65bb248edfe)